### PR TITLE
:sparkles: [PR]2025/02/17 제공자별 예약 조회&만료일 필터링-정은미:sparkles:

### DIFF
--- a/funniture/src/main/java/com/ohgiraffers/funniture/rental/controllers/RentalController.java
+++ b/funniture/src/main/java/com/ohgiraffers/funniture/rental/controllers/RentalController.java
@@ -1,9 +1,6 @@
 package com.ohgiraffers.funniture.rental.controllers;
 
-import com.ohgiraffers.funniture.rental.model.dto.AdminRentalViewDTO;
-import com.ohgiraffers.funniture.rental.model.dto.RentalDTO;
-import com.ohgiraffers.funniture.rental.model.dto.AdminRentalSearchCriteria;
-import com.ohgiraffers.funniture.rental.model.dto.UserOrderViewDTO;
+import com.ohgiraffers.funniture.rental.model.dto.*;
 import com.ohgiraffers.funniture.rental.model.service.RentalService;
 import com.ohgiraffers.funniture.response.ResponseMessage;
 import io.swagger.v3.oas.annotations.Operation;
@@ -34,6 +31,9 @@ import java.util.Map;
 public class RentalController {
 
     private final RentalService rentalService;
+
+
+    /* comment.-------------------------------------------- 사용자 -----------------------------------------------*/
 
     @Operation(summary = "사용자 상품 예약 등록",
             description = "예약 등록 페이지에서 사용"
@@ -90,6 +90,43 @@ public class RentalController {
 
     // 예약 상세 조회(사용자, 제공자 동일) /{rentalNo}
 
+    /* comment.-------------------------------------------- 제공자 -----------------------------------------------*/
+
+    @Operation(summary = "제공자별 예약 조회",
+            description = "제공자 마이페이지 예약/배송/반납에서 사용",
+            parameters = {
+                    @Parameter(name = "ownerNo", description = "제공자 ID(필수)"),
+                    @Parameter(name = "currentDate", description = "현재날짜로(currentDate)부터 만료일(rental_end_date) 1주일/1개월/3개월 필터링(선택)")
+            }
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "204",description = "예약 내역이 없습니다."),
+            @ApiResponse(responseCode = "200", description = "제공자별 예약 조회 성공")
+    })
+    @GetMapping("/owner")
+    public ResponseEntity<ResponseMessage> findRentalListByOwner(@RequestParam String ownerNo, @RequestParam String period) {
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(new MediaType("Application", "json", Charset.forName("UTF-8")));
+
+        List<OwnerRentalViewDTO> ownerRentalList = rentalService.findRentalListByOwner(ownerNo, period);
+
+        if (ownerRentalList.isEmpty()){
+            return ResponseEntity.ok()
+                    .headers(headers)
+                    .body(new ResponseMessage(204, "예약 내역이 없습니다.", null));
+        }
+
+        Map<String, Object> res = new HashMap<>();
+        res.put("ownerRentalList", ownerRentalList);
+
+        return ResponseEntity.ok().headers(headers).body(new ResponseMessage(200, "제공자별 예약 조회 성공", res));
+    }
+
+
+
+
+    /* comment.-------------------------------------------- 관리자 -----------------------------------------------*/
 
     @Operation(summary = "예약 전체 조회",
             description = "관리자 예약정보페이지에서 사용",

--- a/funniture/src/main/java/com/ohgiraffers/funniture/rental/model/dao/OwnerRentalRepositoryCustom.java
+++ b/funniture/src/main/java/com/ohgiraffers/funniture/rental/model/dao/OwnerRentalRepositoryCustom.java
@@ -1,0 +1,11 @@
+package com.ohgiraffers.funniture.rental.model.dao;
+
+import com.ohgiraffers.funniture.rental.model.dto.OwnerRentalViewDTO;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface OwnerRentalRepositoryCustom {
+    List<OwnerRentalViewDTO> findRentalListByOwner(String ownerNo, String period);
+}

--- a/funniture/src/main/java/com/ohgiraffers/funniture/rental/model/dao/OwnerRentalRepositoryCustomImpl.java
+++ b/funniture/src/main/java/com/ohgiraffers/funniture/rental/model/dao/OwnerRentalRepositoryCustomImpl.java
@@ -1,0 +1,81 @@
+package com.ohgiraffers.funniture.rental.model.dao;
+
+import com.ohgiraffers.funniture.product.entity.QRentalOptionInfoEntity;
+import com.ohgiraffers.funniture.rental.entity.QUserProductEntity;
+import com.ohgiraffers.funniture.rental.entity.QUserRentalEntity;
+import com.ohgiraffers.funniture.rental.model.dto.OwnerRentalViewDTO;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class OwnerRentalRepositoryCustomImpl implements OwnerRentalRepositoryCustom{
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public List<OwnerRentalViewDTO> findRentalListByOwner(String ownerNo, String period) {
+
+        // 현재 날짜
+        LocalDate currentDate = LocalDate.now();  // 현재 날짜를 사용
+
+        // User 쪽과 조인이 같아서 재사용!
+        QUserRentalEntity rental = QUserRentalEntity.userRentalEntity;
+        QUserProductEntity product = QUserProductEntity.userProductEntity;
+        QRentalOptionInfoEntity optionInfo = QRentalOptionInfoEntity.rentalOptionInfoEntity;
+
+        // 기본적으로 전체 데이터를 조회할 때는 기간 필터를 추가하지 않음
+        BooleanBuilder whereCondition = new BooleanBuilder();
+        whereCondition.and(rental.ownerNo.eq(ownerNo));
+
+        // 기간에 맞는 조건을 추가
+        if (period != null) {
+            LocalDateTime startDate = null;
+            LocalDateTime endDate = LocalDateTime.now(); // 기본적으로 현재 날짜로 설정
+
+            // 기간 버튼에 따라 날짜 범위 설정
+            if ("1WEEK".equals(period)) {
+                startDate = currentDate.minusWeeks(1).atStartOfDay();
+            } else if ("1MONTH".equals(period)) {
+                startDate = currentDate.minusMonths(1).atStartOfDay();
+            } else if ("3MONTH".equals(period)) {
+                startDate = currentDate.minusMonths(3).atStartOfDay();
+            }
+
+            // 만약 startDate가 설정되었다면, 해당 기간에 맞는 필터링을 적용
+            if (startDate != null) {
+                whereCondition.and(rental.rentalEndDate.between(startDate, endDate));
+            }
+        }
+
+        // QueryDSL을 사용하여 쿼리 실행
+        JPAQuery<OwnerRentalViewDTO> query = jpaQueryFactory
+                .select(Projections.constructor(OwnerRentalViewDTO.class,
+                        rental.rentalNo,
+                        rental.deliverCom,
+                        rental.deliveryNo,
+                        rental.rentalNumber,
+                        rental.rentalStartDate,
+                        rental.rentalEndDate,
+                        rental.rentalState,
+                        product.productName,
+                        optionInfo.rentalTerm,
+                        optionInfo.asNumber
+                ))
+                .from(rental)
+                .join(rental.productEntity, product)
+                .join(rental.rentalOptionInfoEntity, optionInfo)
+                .where(whereCondition);
+
+        return query.fetch();
+    }
+}

--- a/funniture/src/main/java/com/ohgiraffers/funniture/rental/model/dto/OwnerRentalViewDTO.java
+++ b/funniture/src/main/java/com/ohgiraffers/funniture/rental/model/dto/OwnerRentalViewDTO.java
@@ -1,0 +1,37 @@
+package com.ohgiraffers.funniture.rental.model.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@ToString
+public class OwnerRentalViewDTO {
+
+    private String rentalNo;
+
+    private String deliverCom;
+
+    private String deliveryNo;
+
+    private int rentalNumber;
+
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private LocalDateTime rentalStartDate;
+
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private LocalDateTime rentalEndDate;
+
+    private String rentalState;
+
+    private String productName;
+
+    private int rentalTerm;
+
+    private int asNumber;
+
+}

--- a/funniture/src/main/java/com/ohgiraffers/funniture/rental/model/service/RentalService.java
+++ b/funniture/src/main/java/com/ohgiraffers/funniture/rental/model/service/RentalService.java
@@ -2,10 +2,7 @@ package com.ohgiraffers.funniture.rental.model.service;
 
 import com.ohgiraffers.funniture.rental.entity.RentalEntity;
 import com.ohgiraffers.funniture.rental.model.dao.*;
-import com.ohgiraffers.funniture.rental.model.dto.AdminRentalViewDTO;
-import com.ohgiraffers.funniture.rental.model.dto.RentalDTO;
-import com.ohgiraffers.funniture.rental.model.dto.AdminRentalSearchCriteria;
-import com.ohgiraffers.funniture.rental.model.dto.UserOrderViewDTO;
+import com.ohgiraffers.funniture.rental.model.dto.*;
 import lombok.RequiredArgsConstructor;
 import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Service;
@@ -25,6 +22,7 @@ public class RentalService {
     private final ModelMapper modelMapper;
     private final AdminRentalRepositoryCustom adminRentalRepositoryCustom;
     private final UserRentalRepositoryCustom userRentalRepositoryCustom;
+    private final OwnerRentalRepositoryCustom ownerRentalRepositoryCustom;
 
     // 사용자 - 예약 등록
     @Transactional
@@ -55,17 +53,19 @@ public class RentalService {
         rentalRepository.save(modelMapper.map(rentalDTO, RentalEntity.class));
     }
 
-    // 사용자 - 예약 조회(쿼리DSL)
+    // 사용자 - 예약 조회(쿼리 DSL)
     public List<UserOrderViewDTO> findRentalOrderListByUser(String memberId, String period, LocalDate searchDate) {
         return userRentalRepositoryCustom.findRentalOrderListByUser(memberId,period, searchDate);
     }
 
 
-    // 관리자 - 예약 전체 조회(쿼리DSL)
+    // 관리자 - 예약 조회(쿼리 DSL)
     public List<AdminRentalViewDTO> findRentalAllListByAdmin(AdminRentalSearchCriteria criteria) {
         return adminRentalRepositoryCustom.findRentalAllListByAdmin(criteria);
     }
 
-
-
+    // 제공자 - 예약 조회(쿼리 DSL)
+    public List<OwnerRentalViewDTO> findRentalListByOwner(String ownerNo, String period) {
+        return ownerRentalRepositoryCustom.findRentalListByOwner(ownerNo,period);
+    }
 }


### PR DESCRIPTION
## #️⃣ Issue Number

#106

## 📝 요약(Summary)

제공자별 예약 조회&만료일 필터링
- User 예약조회 엔티티 재사용(조인 일치)
- OwnerRentalViewDTO 추가
- OwnerRentalRepositoryCustom 추가
- OwnerRentalRepositoryCustomImpl 추가

## 💻 백엔드 PR 유형

### ✨ 기능 및 API  
- [x] 새 API 추가
- [ ] 기존 API 수정
- [ ] API의 엔드포인트(URL) 수정
- [ ] 데이터베이스 구조 변경 (엔티티, 테이블, 컬럼 수정)
- [ ] API 응답 구조 변경 (ResponseMessage 필드명, 데이터 구조 수정)

### 🛠️ 보안 및 성능      
- [ ] 성능 개선 (쿼리 최적화, 캐싱)  
- [ ] 보안 관련 수정 (인증/인가, 데이터 검증)
- [ ] 예외 처리 개선 (예외 핸들링 로직 추가/수정)

### 😈 버그  
- [ ] 버그 수정

### 🎸 기타  
- [ ] API 문서화 (Swagger 설정 추가/수정)
- [ ] 코드 리팩토링 (파일/폴더명 변경, 코드 스타일 정리)
- [ ] 불필요한 코드 및 파일 삭제
- [ ] 주석 추가 및 수정  
- [ ] 테스트 코드 추가 및 수정
- [ ] 기타

## 📸스크린샷 (선택)

![image](https://github.com/user-attachments/assets/8675aeb3-15b4-41fd-b9df-b451a6d14252)

## ✅ PR Checklist
📢 merge 할 분 이름에 체크해주세요.
- [ ] 김규남
- [ ] 김경훈
- [ ] 박재민
- [ ] 정예진
- [x] 정은미

