### PR TITLE
 ✨[PR]2025/02/18 로그인 한 유저의 대한 정보 가져오기 - 김규남✨

### DIFF
--- a/funniture/src/main/java/com/ohgiraffers/funniture/auth/filter/JwtAuthorizationFilter.java
+++ b/funniture/src/main/java/com/ohgiraffers/funniture/auth/filter/JwtAuthorizationFilter.java
@@ -40,6 +40,8 @@ public class JwtAuthorizationFilter extends BasicAuthenticationFilter {
         * */
 
         List<String> roleLeessList = Arrays.asList(
+                "/api/v1/member(/\\w+)?",
+                "/api/v1/member",
                 "/api/v1/product/\\d+",
                 "/api/v1/product/\\w+",
                 "/api/v1/product",

--- a/funniture/src/main/java/com/ohgiraffers/funniture/member/controller/AuthController.java
+++ b/funniture/src/main/java/com/ohgiraffers/funniture/member/controller/AuthController.java
@@ -23,7 +23,7 @@ public class AuthController {
 
     private final AuthService authService;
 
-    private HttpHeaders headersMethod () {
+    public HttpHeaders headersMethod () {
 
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(new MediaType("application", "json", Charset.forName("UTF-8")));

--- a/funniture/src/main/java/com/ohgiraffers/funniture/member/controller/MemberController.java
+++ b/funniture/src/main/java/com/ohgiraffers/funniture/member/controller/MemberController.java
@@ -1,0 +1,25 @@
+package com.ohgiraffers.funniture.member.controller;
+
+import com.ohgiraffers.funniture.member.model.service.MemberService;
+import com.ohgiraffers.funniture.response.ResponseMessage;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/member")
+public class MemberController {
+
+    private MemberService memberService;
+
+    private AuthController authController;
+
+//    @GetMapping
+//    public ResponseEntity<ResponseMessage> memberList () {
+//
+//        return ResponseEntity.ok()
+//                .headers(authController.headersMethod())
+//                .body(new ResponseMessage(200, "회원 전체 목록 조회 성공", result));
+//    }
+}

--- a/funniture/src/main/java/com/ohgiraffers/funniture/member/controller/MemberController.java
+++ b/funniture/src/main/java/com/ohgiraffers/funniture/member/controller/MemberController.java
@@ -1,25 +1,37 @@
 package com.ohgiraffers.funniture.member.controller;
 
+import com.ohgiraffers.funniture.member.model.dto.MemberDTO;
 import com.ohgiraffers.funniture.member.model.service.MemberService;
 import com.ohgiraffers.funniture.response.ResponseMessage;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/api/v1/member")
+@RequiredArgsConstructor
 public class MemberController {
 
-    private MemberService memberService;
+    private final MemberService memberService;
 
-    private AuthController authController;
+    private final AuthController authController;
 
-//    @GetMapping
-//    public ResponseEntity<ResponseMessage> memberList () {
-//
-//        return ResponseEntity.ok()
-//                .headers(authController.headersMethod())
-//                .body(new ResponseMessage(200, "회원 전체 목록 조회 성공", result));
-//    }
+    @GetMapping("/{memberId}")
+    public ResponseEntity<ResponseMessage> memberList (@PathVariable String memberId) {
+        System.out.println("화면에서 넘어온 memberId"+ memberId);
+        System.out.println("✅ memberList 조회를 위한 memberList 컨트롤러 동작..");
+
+        MemberDTO memberDTO = memberService.getMemberList(memberId);
+        System.out.println("✅ 서비스에서 넘어온 로그인 회원 목록 = " + memberDTO);
+        Map<String , Object> result = new HashMap<>();
+        result.put("result" , memberDTO);
+
+        return ResponseEntity.ok()
+                .headers(authController.headersMethod())
+                .body(new ResponseMessage(200, "로그인 한 회원 목록 조회 성공", result));
+    }
 }

--- a/funniture/src/main/java/com/ohgiraffers/funniture/member/entity/MemberEntity.java
+++ b/funniture/src/main/java/com/ohgiraffers/funniture/member/entity/MemberEntity.java
@@ -40,8 +40,10 @@ public class MemberEntity {
     @Column(name = "is_consulting")
     private int isConsulting;
 
-    @Column (name = "has_image")
-    private int hasImage;
+    // hasImage에 null도 들어가 있을 때 조회하면 에러 발생하므로
+    // nullable = true 추가하였고, Integer로 변경 (250218)
+    @Column (name = "has_image", nullable = true)
+    private Integer hasImage;
 
     @Column(name = "image_id")
     private String imageId;

--- a/funniture/src/main/java/com/ohgiraffers/funniture/member/model/service/MemberService.java
+++ b/funniture/src/main/java/com/ohgiraffers/funniture/member/model/service/MemberService.java
@@ -1,0 +1,7 @@
+package com.ohgiraffers.funniture.member.model.service;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class MemberService {
+}

--- a/funniture/src/main/java/com/ohgiraffers/funniture/member/model/service/MemberService.java
+++ b/funniture/src/main/java/com/ohgiraffers/funniture/member/model/service/MemberService.java
@@ -1,7 +1,28 @@
 package com.ohgiraffers.funniture.member.model.service;
 
+import com.ohgiraffers.funniture.member.entity.MemberEntity;
+import com.ohgiraffers.funniture.member.model.dao.MemberRepository;
+import com.ohgiraffers.funniture.member.model.dto.MemberDTO;
+import lombok.RequiredArgsConstructor;
+import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
 @Service
+@RequiredArgsConstructor
 public class MemberService {
+
+    private final MemberRepository memberRepository;
+    private final ModelMapper modelMapper;
+
+    public MemberDTO getMemberList(String memberId) {
+
+        Optional<MemberEntity> memberEntity = memberRepository.findById(memberId);
+        System.out.println("✅ 로그인한 정보 찾아온 엔티티 값 : " + memberEntity);
+
+        return modelMapper.map(memberEntity , MemberDTO.class);
+    }
 }


### PR DESCRIPTION
## #️⃣ Issue Number

#109 
#113 

## 📝 요약(Summary)

- 로그인 한 정보에 대해 서버에서 가져오는 로직 구현
- api/v1/member/{memberId}

## 💻 백엔드 PR 유형

### ✨ 기능 및 API  
- [x] 새 API 추가
- [ ] 기존 API 수정
- [ ] API의 엔드포인트(URL) 수정
- [ ] 데이터베이스 구조 변경 (엔티티, 테이블, 컬럼 수정)
- [ ] API 응답 구조 변경 (ResponseMessage 필드명, 데이터 구조 수정)

### 🛠️ 보안 및 성능      
- [ ] 성능 개선 (쿼리 최적화, 캐싱)  
- [ ] 보안 관련 수정 (인증/인가, 데이터 검증)
- [ ] 예외 처리 개선 (예외 핸들링 로직 추가/수정)

### 😈 버그  
- [ ] 버그 수정

### 🎸 기타  
- [ ] API 문서화 (Swagger 설정 추가/수정)
- [ ] 코드 리팩토링 (파일/폴더명 변경, 코드 스타일 정리)
- [ ] 불필요한 코드 및 파일 삭제
- [ ] 주석 추가 및 수정  
- [ ] 테스트 코드 추가 및 수정
- [ ] 기타

## 📸스크린샷 (선택)

![image](https://github.com/user-attachments/assets/3b82cd61-dcf2-42e3-ae1d-4ddb0a4a1a19)


## ✅ PR Checklist
📢 merge 할 분 이름에 체크해주세요.
- [x] 김규남
- [ ] 김경훈
- [ ] 박재민
- [ ] 정예진
- [ ] 정은미

