### PR TITLE
⚡️ PR]2025/02/19 로그인 시, 백에서 프론트로 비밀번호 전달되지 않게 수정  - 김규남 ⚡️

### DIFF
--- a/funniture/src/main/java/com/ohgiraffers/funniture/member/controller/MemberController.java
+++ b/funniture/src/main/java/com/ohgiraffers/funniture/member/controller/MemberController.java
@@ -41,6 +41,8 @@ public class MemberController {
 
         MemberDTO memberDTO = memberService.getMemberList(memberId);
         System.out.println("✅ 서비스에서 넘어온 로그인 회원 목록 = " + memberDTO);
+
+        memberDTO.setPassword(null);
         Map<String , Object> result = new HashMap<>();
         result.put("result" , memberDTO);
 


### PR DESCRIPTION
## #️⃣ Issue Number

#121 

## 📝 요약(Summary)

- 로그인 시, 서버에서 패스워드까지 프론트로 넘어갔는데, 패스워드 넘어가지 않게 수정

## 💻 백엔드 PR 유형

### ✨ 기능 및 API  
- [ ] 새 API 추가
- [ ] 기존 API 수정
- [ ] API의 엔드포인트(URL) 수정
- [ ] 데이터베이스 구조 변경 (엔티티, 테이블, 컬럼 수정)
- [ ] API 응답 구조 변경 (ResponseMessage 필드명, 데이터 구조 수정)

### 🛠️ 보안 및 성능      
- [ ] 성능 개선 (쿼리 최적화, 캐싱)  
- [x] 보안 관련 수정 (인증/인가, 데이터 검증)
- [ ] 예외 처리 개선 (예외 핸들링 로직 추가/수정)

### 😈 버그  
- [ ] 버그 수정

### 🎸 기타  
- [ ] API 문서화 (Swagger 설정 추가/수정)
- [ ] 코드 리팩토링 (파일/폴더명 변경, 코드 스타일 정리)
- [ ] 불필요한 코드 및 파일 삭제
- [ ] 주석 추가 및 수정  
- [ ] 테스트 코드 추가 및 수정
- [ ] 기타

## 📸스크린샷 (선택)

![image](https://github.com/user-attachments/assets/c5963cc2-774b-4965-9893-b09b6273aa09)


## ✅ PR Checklist
📢 merge 할 분 이름에 체크해주세요.
- [ ] 김규남
- [ ] 김경훈
- [ ] 박재민
- [ ] 정예진
- [x] 정은미

