### PR TITLE
✨[PR]2025/02/23 사용자 마이페이지 비밀번호 인증 - 김규남 ✨

### DIFF
--- a/funniture/src/main/java/com/ohgiraffers/funniture/member/controller/MemberController.java
+++ b/funniture/src/main/java/com/ohgiraffers/funniture/member/controller/MemberController.java
@@ -88,4 +88,33 @@ public class MemberController {
                     .body(new ResponseMessage(404 , "비밀번호 변경 실패", null));
         }
     }
+
+    @Operation(summary = "사용자 본인 인증",
+            description = "사용자 마이페이지에서 비밀번호 인증")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "성공"),
+            @ApiResponse(responseCode = "404", description = "실패")
+    })
+    @PostMapping("/conform")
+    public ResponseEntity<ResponseMessage> confirmToMyPage (@RequestBody MemberDTO memberDTO) {
+        System.out.println(" 서버에 잘 들어왔나 memberDTO = " + memberDTO);
+
+        String memberId = memberDTO.getMemberId();
+        String password = memberDTO.getPassword();
+        System.out.println("memberId = " + memberId);
+        System.out.println("password = " + password);
+
+        boolean result = memberService.comparePassword(memberId, password);
+
+        if (result) {
+            return ResponseEntity.ok()
+                    .headers(authController.headersMethod())
+                    .body(new ResponseMessage(201,"인증 성공", null));
+        } else {
+            return ResponseEntity.ok()
+                    .headers(authController.headersMethod())
+                    .body(new ResponseMessage(404,"인증 실패", null));
+        }
+    }
+
 }

--- a/funniture/src/main/java/com/ohgiraffers/funniture/member/model/dao/MemberRepository.java
+++ b/funniture/src/main/java/com/ohgiraffers/funniture/member/model/dao/MemberRepository.java
@@ -29,4 +29,6 @@ public interface MemberRepository extends JpaRepository<MemberEntity , String> {
     List<Object[]> findAllOwner();
 
     boolean existsByEmail(String email);
+
+    MemberEntity findByMemberId(String memberId);
 }

--- a/funniture/src/main/java/com/ohgiraffers/funniture/member/model/service/MemberService.java
+++ b/funniture/src/main/java/com/ohgiraffers/funniture/member/model/service/MemberService.java
@@ -55,4 +55,25 @@ public class MemberService {
         System.out.println("비밀번호 변경 완료. : " + result);
         return result;
     }
+
+    public boolean comparePassword(String memberId, String password) {
+
+        System.out.println("서비스에 아이디 비번 잘 넘어 왔는지 memberId = " + memberId + password);
+
+        // 받아온 id 값을 가지고 정보 찾아오기
+        MemberEntity memberEntity = memberRepository.findByMemberId(memberId);
+        System.out.println("memberId로 memberEntity 잘 찾아왔는지 = " + memberEntity);
+
+        // 이미 저장돼있던 인코딩 패스워드
+        String encodedPassword = memberEntity.getPassword();
+
+        // passwordEncoder.matches는 사용자 입력 패스워드(암호화x)와 저장된 암호화 패스워드를 비교해줌
+        if (passwordEncoder.matches(password, encodedPassword)){
+            System.out.println(" 비밀번호 일치 ");
+            return true;
+        } else{
+            System.out.println("비밀번호 불일치");
+            return false;
+        }
+    }
 }


### PR DESCRIPTION
## #️⃣ Issue Number

#150 
#148 

## 📝 요약(Summary)

- 사용자 마이페이지 비밀번호 인증
- 사용자의 입력 패스워드와 인코드 형태로 저장돼있는 패스워드 비교하여 리턴
- passwordEncoder.matches 사용

## 💻 백엔드 PR 유형

### ✨ 기능 및 API  
- [x] 새 API 추가
- [ ] 기존 API 수정
- [ ] API의 엔드포인트(URL) 수정
- [ ] 데이터베이스 구조 변경 (엔티티, 테이블, 컬럼 수정)
- [ ] API 응답 구조 변경 (ResponseMessage 필드명, 데이터 구조 수정)

### 🛠️ 보안 및 성능      
- [ ] 성능 개선 (쿼리 최적화, 캐싱)  
- [ ] 보안 관련 수정 (인증/인가, 데이터 검증)
- [ ] 예외 처리 개선 (예외 핸들링 로직 추가/수정)

### 😈 버그  
- [ ] 버그 수정

### 🎸 기타  
- [ ] API 문서화 (Swagger 설정 추가/수정)
- [ ] 코드 리팩토링 (파일/폴더명 변경, 코드 스타일 정리)
- [ ] 불필요한 코드 및 파일 삭제
- [ ] 주석 추가 및 수정  
- [ ] 테스트 코드 추가 및 수정
- [ ] 기타

## 📸스크린샷 (선택)



## ✅ PR Checklist
📢 merge 할 분 이름에 체크해주세요.
- [x] 김규남
- [ ] 김경훈
- [ ] 박재민
- [ ] 정예진
- [ ] 정은미

