### PR TITLE
:sparkles:[PR]2025/02/23 배송지 수정 기능 , 스웨거 추가 및 배송지 등록 수정 - 정은미:art:

### DIFF
--- a/funniture/src/main/java/com/ohgiraffers/funniture/auth/filter/JwtAuthorizationFilter.java
+++ b/funniture/src/main/java/com/ohgiraffers/funniture/auth/filter/JwtAuthorizationFilter.java
@@ -69,6 +69,7 @@ public class JwtAuthorizationFilter extends BasicAuthenticationFilter {
                 "/api/v1/deliveryaddress/\\w+",
                 "/api/v1/deliveryaddress/\\d+",
                 "/api/v1/deliveryaddress/regist",
+                "/api/v1/deliveryaddress/update",
                 "/api/v1/review/product/\\d+",
                 "/api/v1/product/search?s=\\w+",
                 "/api/v1/review",

--- a/funniture/src/main/java/com/ohgiraffers/funniture/deliveryaddress/controllers/DeliveryAddressController.java
+++ b/funniture/src/main/java/com/ohgiraffers/funniture/deliveryaddress/controllers/DeliveryAddressController.java
@@ -75,6 +75,17 @@ public class DeliveryAddressController {
         return ResponseEntity.ok().headers(headers).body(new ResponseMessage(201, "신규배송지 등록이 완료되었습니다.", null));
     }
 
+    // 배송지 수정
+    @PutMapping("/update")
+    public ResponseEntity<ResponseMessage> deliveryAddressUpdate(@RequestBody DeliveryAddressDTO deliveryAddressDTO) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(new MediaType("Application", "json", Charset.forName("UTF-8")));
+
+        deliveryAddressService.deliveryAddressUpdate(deliveryAddressDTO);
+
+        return ResponseEntity.ok().headers(headers).body(new ResponseMessage(200, "신규배송지 수정이 완료되었습니다.", null));
+    }
+
 
 
 

--- a/funniture/src/main/java/com/ohgiraffers/funniture/deliveryaddress/controllers/DeliveryAddressController.java
+++ b/funniture/src/main/java/com/ohgiraffers/funniture/deliveryaddress/controllers/DeliveryAddressController.java
@@ -75,6 +75,12 @@ public class DeliveryAddressController {
         return ResponseEntity.ok().headers(headers).body(new ResponseMessage(201, "신규배송지 등록이 완료되었습니다.", null));
     }
 
+    @Operation(summary = "사용자 배송지 수정",
+            description = "예약 등록 페이지, 마이페이지에서 사용"
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "배송지 수정이 완료되었습니다.")
+    })
     // 배송지 수정
     @PutMapping("/update")
     public ResponseEntity<ResponseMessage> deliveryAddressUpdate(@RequestBody DeliveryAddressDTO deliveryAddressDTO) {
@@ -83,7 +89,7 @@ public class DeliveryAddressController {
 
         deliveryAddressService.deliveryAddressUpdate(deliveryAddressDTO);
 
-        return ResponseEntity.ok().headers(headers).body(new ResponseMessage(200, "신규배송지 수정이 완료되었습니다.", null));
+        return ResponseEntity.ok().headers(headers).body(new ResponseMessage(200, "배송지 수정이 완료되었습니다.", null));
     }
 
 

--- a/funniture/src/main/java/com/ohgiraffers/funniture/deliveryaddress/entity/DeliveryAddressEntity.java
+++ b/funniture/src/main/java/com/ohgiraffers/funniture/deliveryaddress/entity/DeliveryAddressEntity.java
@@ -1,17 +1,16 @@
 package com.ohgiraffers.funniture.deliveryaddress.entity;
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.*;
 
 @Entity
 @Table(name = "tbl_postaddress")
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
+@Setter
 @ToString
+@Builder(toBuilder = true)
 public class DeliveryAddressEntity {
 
     @Id

--- a/funniture/src/main/java/com/ohgiraffers/funniture/deliveryaddress/model/dao/DeliveryAddressRepository.java
+++ b/funniture/src/main/java/com/ohgiraffers/funniture/deliveryaddress/model/dao/DeliveryAddressRepository.java
@@ -6,10 +6,13 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface DeliveryAddressRepository extends JpaRepository<DeliveryAddressEntity, Integer> {
 
     @Query("SELECT d FROM DeliveryAddressEntity d WHERE d.memberId = :memberId")
     List<DeliveryAddressEntity> findDeliveryAddressByUser(String memberId);
+
+    Optional<DeliveryAddressEntity> findByMemberIdAndIsDefaultTrue(String memberId);
 }

--- a/funniture/src/main/java/com/ohgiraffers/funniture/deliveryaddress/model/dto/DeliveryAddressDTO.java
+++ b/funniture/src/main/java/com/ohgiraffers/funniture/deliveryaddress/model/dto/DeliveryAddressDTO.java
@@ -22,7 +22,7 @@ public class DeliveryAddressDTO {
 
     private String receiver;            // 받는 이
 
-    private boolean isDefault;          // 기본배송지 여부
+    private Integer isDefault;       // 기본배송지 여부
 
 
 }

--- a/funniture/src/main/java/com/ohgiraffers/funniture/deliveryaddress/model/service/DeliveryAddressService.java
+++ b/funniture/src/main/java/com/ohgiraffers/funniture/deliveryaddress/model/service/DeliveryAddressService.java
@@ -10,8 +10,10 @@ import jakarta.persistence.Id;
 import lombok.RequiredArgsConstructor;
 import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -28,8 +30,64 @@ public class DeliveryAddressService {
         return addressList.stream().map(address -> modelMapper.map(address, DeliveryAddressDTO.class)).collect(Collectors.toList());
     }
 
+    @Transactional
     public void deliveryAddressRegist(DeliveryAddressDTO deliveryAddressDTO) {
 
+        // Entity 변환
+        DeliveryAddressEntity deliveryAddressEntity = modelMapper.map(deliveryAddressDTO, DeliveryAddressEntity.class);
+
+        if (deliveryAddressDTO.getIsDefault() != null && deliveryAddressDTO.getIsDefault() == 1) {
+            // 새로운 주소가 기본 배송지로 등록하려는 경우
+            // 먼저, 해당 회원의 기본 배송지가 있는지 확인
+            Optional<DeliveryAddressEntity> existingDefaultAddress =
+                    deliveryAddressRepository.findByMemberIdAndIsDefaultTrue(deliveryAddressDTO.getMemberId());
+
+            // 기본 배송지가 존재하면 기본 배송지를 false로 설정
+            existingDefaultAddress.ifPresent(address -> {
+                // 기존 기본 배송지를 false로 업데이트
+                address.setDefault(false);
+                deliveryAddressRepository.save(address);
+            });
+
+            // 새로 등록되는 배송지는 기본 배송지로 설정
+            deliveryAddressEntity.setDefault(true);
+        }
+
         deliveryAddressRepository.save(modelMapper.map(deliveryAddressDTO, DeliveryAddressEntity.class));
+    }
+
+    @Transactional
+    public void deliveryAddressUpdate(DeliveryAddressDTO deliveryAddressDTO) {
+
+        // 수정할 배송지 찾기
+        DeliveryAddressEntity deliveryAddressEntity =
+                deliveryAddressRepository.findById(deliveryAddressDTO.getDestinationNo())
+                        .orElseThrow(() -> new IllegalArgumentException("해당 배송지가 존재하지 않습니다."));
+
+        // 만약 사용자가 기본 배송지를 설정하려는 경우
+        if (deliveryAddressDTO.getIsDefault() != null && deliveryAddressDTO.getIsDefault() == 1) {
+            // 해당 회원(memberId)의 기존 기본 배송지 찾기
+            Optional<DeliveryAddressEntity> existingDefaultAddress =
+                    deliveryAddressRepository.findByMemberIdAndIsDefaultTrue(deliveryAddressEntity.getMemberId());
+
+            // 기존 기본 배송지가 있다면 기본 배송지 해제 (isDefault = false)
+            existingDefaultAddress.ifPresent(address -> {
+                DeliveryAddressEntity updatedOldDefault = address.toBuilder().isDefault(false).build();
+                deliveryAddressRepository.save(updatedOldDefault);
+            });
+
+
+        }
+
+        // 새로운 수정된 배송지 생성 및 저장
+        DeliveryAddressEntity updateDeliveryAddress = deliveryAddressEntity.toBuilder()
+                .destinationName(deliveryAddressDTO.getDestinationName())   // 배송지 이름 수정
+                .destinationPhone(deliveryAddressDTO.getDestinationPhone()) // 배송지 전화번호 수정
+                .destinationAddress(deliveryAddressDTO.getDestinationAddress()) // 배송지 수정
+                .receiver(deliveryAddressDTO.getReceiver())                 // 받는 이 수정
+                .isDefault(deliveryAddressDTO.getIsDefault() != null && deliveryAddressDTO.getIsDefault() == 1) // 기본배송지 여부 수정
+                .build();
+
+        deliveryAddressRepository.save(updateDeliveryAddress);
     }
 }


### PR DESCRIPTION
## #️⃣ Issue Number

#156 , #155 

## 📝 요약(Summary)

- 배송지 수정 API 추가 
- 스웨거 추가
- 사용자가 신규 배송지 등록 시 기본배송지(true)로 선택하면서 등록한다면 
  원래 사용자의 기본배송지였던 것을 false 로 save 후 신규 배송지를 기본배송지로 등록되게 수정
  => 배송지 수정 기능을 하면서 기본배송지 문제를 확인하여 pr 수정, 등록 기능 구분 못했습니다..!ㅜ
- doFilterInternal 에 경로 추가

## 💻 백엔드 PR 유형

### ✨ 기능 및 API  
- [x] 새 API 추가
- [x] 기존 API 수정
- [ ] API의 엔드포인트(URL) 수정
- [ ] 데이터베이스 구조 변경 (엔티티, 테이블, 컬럼 수정)
- [ ] API 응답 구조 변경 (ResponseMessage 필드명, 데이터 구조 수정)

### 🛠️ 보안 및 성능      
- [ ] 성능 개선 (쿼리 최적화, 캐싱)  
- [ ] 보안 관련 수정 (인증/인가, 데이터 검증)
- [ ] 예외 처리 개선 (예외 핸들링 로직 추가/수정)

### 😈 버그  
- [ ] 버그 수정

### 🎸 기타  
- [x] API 문서화 (Swagger 설정 추가/수정)
- [ ] 코드 리팩토링 (파일/폴더명 변경, 코드 스타일 정리)
- [ ] 불필요한 코드 및 파일 삭제
- [ ] 주석 추가 및 수정  
- [ ] 테스트 코드 추가 및 수정
- [ ] 기타

## 📸스크린샷 (선택)

![image](https://github.com/user-attachments/assets/6c7e9bde-6163-4a78-961c-e950de5bfd42)

![image](https://github.com/user-attachments/assets/73e0ce00-a461-4e45-90aa-c65ca3c43805)



## ✅ PR Checklist
📢 merge 할 분 이름에 체크해주세요.
- [ ] 김규남
- [ ] 김경훈
- [ ] 박재민
- [ ] 정예진
- [x] 정은미

