### PR TITLE
:sparkles:[PR]2025/02/23 배송지 삭제 기능 스웨거 추가 및 조회 수정 -정은미:art:

### DIFF
--- a/funniture/src/main/java/com/ohgiraffers/funniture/auth/filter/JwtAuthorizationFilter.java
+++ b/funniture/src/main/java/com/ohgiraffers/funniture/auth/filter/JwtAuthorizationFilter.java
@@ -70,6 +70,8 @@ public class JwtAuthorizationFilter extends BasicAuthenticationFilter {
                 "/api/v1/deliveryaddress/\\d+",
                 "/api/v1/deliveryaddress/regist",
                 "/api/v1/deliveryaddress/update",
+                "/api/v1/deliveryaddress/delete/\\d+",
+                "/api/v1/deliveryaddress/delete/\\w+",
                 "/api/v1/review/product/\\d+",
                 "/api/v1/product/search?s=\\w+",
                 "/api/v1/review",

--- a/funniture/src/main/java/com/ohgiraffers/funniture/deliveryaddress/controllers/DeliveryAddressController.java
+++ b/funniture/src/main/java/com/ohgiraffers/funniture/deliveryaddress/controllers/DeliveryAddressController.java
@@ -92,6 +92,24 @@ public class DeliveryAddressController {
         return ResponseEntity.ok().headers(headers).body(new ResponseMessage(200, "배송지 수정이 완료되었습니다.", null));
     }
 
+    @Operation(summary = "배송지 비활성화",
+            description = "예약 등록 페이지, 마이페이지에서 사용"
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "배송지가 비활성화되었습니다.")
+    })
+    // 사용자 배송지 삭제(사용자 입장에서 안보이게하기 -> 과거 예약에서 배송지가 확인 되어야하기때문에)
+    @PutMapping("/delete/{destinationNo}")
+    public ResponseEntity<ResponseMessage> deliveryAddressDelete(@PathVariable int destinationNo){
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(new MediaType("Application", "json", Charset.forName("UTF-8")));
+
+        // 서비스에서 배송지 상태를 '비활성화'로 변경
+        deliveryAddressService.deliveryAddressDelete(destinationNo);
+
+        return ResponseEntity.ok(new ResponseMessage(200, "배송지가 비활성화되었습니다.", null));
+    }
+
 
 
 

--- a/funniture/src/main/java/com/ohgiraffers/funniture/deliveryaddress/entity/DeliveryAddressEntity.java
+++ b/funniture/src/main/java/com/ohgiraffers/funniture/deliveryaddress/entity/DeliveryAddressEntity.java
@@ -2,6 +2,9 @@ package com.ohgiraffers.funniture.deliveryaddress.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "tbl_postaddress")
@@ -36,4 +39,12 @@ public class DeliveryAddressEntity {
 
     @Column(name = "is_default")
     private boolean isDefault;          // 기본배송지 여부
+
+    @CreationTimestamp
+    @Column(name = "created_at", columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
+    private LocalDateTime createdAt;    // 생성일시
+
+    @Column(name = "destination_status")
+    private String destinationStatus;              // 배송지 상태 (활성화, 비활성화)
+
 }

--- a/funniture/src/main/java/com/ohgiraffers/funniture/deliveryaddress/model/dao/DeliveryAddressRepository.java
+++ b/funniture/src/main/java/com/ohgiraffers/funniture/deliveryaddress/model/dao/DeliveryAddressRepository.java
@@ -11,8 +11,12 @@ import java.util.Optional;
 @Repository
 public interface DeliveryAddressRepository extends JpaRepository<DeliveryAddressEntity, Integer> {
 
-    @Query("SELECT d FROM DeliveryAddressEntity d WHERE d.memberId = :memberId")
+    @Query("SELECT d FROM DeliveryAddressEntity d WHERE d.memberId = :memberId and d.destinationStatus = '활성화'")
     List<DeliveryAddressEntity> findDeliveryAddressByUser(String memberId);
 
     Optional<DeliveryAddressEntity> findByMemberIdAndIsDefaultTrue(String memberId);
+
+    Optional<DeliveryAddressEntity> findTopByMemberIdAndDestinationStatusOrderByCreatedAtDesc(
+            String memberId, String destinationStatus);
+
 }

--- a/funniture/src/main/java/com/ohgiraffers/funniture/deliveryaddress/model/dto/DeliveryAddressDTO.java
+++ b/funniture/src/main/java/com/ohgiraffers/funniture/deliveryaddress/model/dto/DeliveryAddressDTO.java
@@ -22,7 +22,9 @@ public class DeliveryAddressDTO {
 
     private String receiver;            // 받는 이
 
-    private Integer isDefault;       // 기본배송지 여부
+    private Integer isDefault;          // 기본배송지 여부
+
+    private String destinationStatus;   // 배송지 상태 (활성화 , 비활성화)
 
 
 }


### PR DESCRIPTION
## #️⃣ Issue Number

#157 

## 📝 요약(Summary)

- 사용자 배송지삭제 기능 (DeleteMapping X) 
  => 과거 예약내역에서 배송지가 확인 되어야하기 때문에 DB 삭제 X
- 사용자별 배송지 조회 조건 추가 
  => destination_status = "활성화" 만 조회
- 스웨거 추가

## 💻 백엔드 PR 유형

### ✨ 기능 및 API  
- [x] 새 API 추가
- [x] 기존 API 수정
- [ ] API의 엔드포인트(URL) 수정
- [ ] 데이터베이스 구조 변경 (엔티티, 테이블, 컬럼 수정)
- [ ] API 응답 구조 변경 (ResponseMessage 필드명, 데이터 구조 수정)

### 🛠️ 보안 및 성능      
- [ ] 성능 개선 (쿼리 최적화, 캐싱)  
- [ ] 보안 관련 수정 (인증/인가, 데이터 검증)
- [ ] 예외 처리 개선 (예외 핸들링 로직 추가/수정)

### 😈 버그  
- [ ] 버그 수정

### 🎸 기타  
- [x] API 문서화 (Swagger 설정 추가/수정)
- [ ] 코드 리팩토링 (파일/폴더명 변경, 코드 스타일 정리)
- [ ] 불필요한 코드 및 파일 삭제
- [ ] 주석 추가 및 수정  
- [ ] 테스트 코드 추가 및 수정
- [ ] 기타

## 📸스크린샷 (선택)

![image](https://github.com/user-attachments/assets/efc17a84-2a43-499d-88c1-27d6dd0d22b0)
![image](https://github.com/user-attachments/assets/26c52dec-1740-434f-ab8b-6f96801e9890)


## ✅ PR Checklist
📢 merge 할 분 이름에 체크해주세요.
- [ ] 김규남
- [ ] 김경훈
- [ ] 박재민
- [ ] 정예진
- [x] 정은미

