### PR TITLE
✨[PR]2025/02/24 주소 정보 불러오기 위한 memberDTO / MemberEntity에 address 추가 - 김규남 ✨

### DIFF
--- a/funniture/src/main/java/com/ohgiraffers/funniture/member/entity/MemberEntity.java
+++ b/funniture/src/main/java/com/ohgiraffers/funniture/member/entity/MemberEntity.java
@@ -49,6 +49,9 @@ public class MemberEntity {
     @Column(name = "image_link")
     private String imageLink;
 
+    @Column(name = "address")
+    private String address;
+
     protected MemberEntity(){}
 
     public MemberEntity password(String password){
@@ -57,7 +60,7 @@ public class MemberEntity {
     }
 
     public MemberEntity create(){
-        return new MemberEntity(memberId, email,password,userName,phoneNumber,signupDate,memberRole,isConsulting,hasImage,imageId,imageLink);
+        return new MemberEntity(memberId, email,password,userName,phoneNumber,signupDate,memberRole,isConsulting,hasImage,imageId,imageLink,address);
     }
 
 //    // 연관관계 설정 (한 명의 회원이 여러 개의 상품을 소유할 수 있음)

--- a/funniture/src/main/java/com/ohgiraffers/funniture/member/model/dto/MemberDTO.java
+++ b/funniture/src/main/java/com/ohgiraffers/funniture/member/model/dto/MemberDTO.java
@@ -42,6 +42,8 @@ public class MemberDTO implements UserDetails {
     private String imageId;
     private Collection<GrantedAuthority> authorities;
 
+    private String address;
+
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
         Collection<GrantedAuthority> authorities = new ArrayList<>();


### PR DESCRIPTION

## #️⃣ Issue Number

#163 
#164 

## 📝 요약(Summary)

- 사용자 마이 페이지에서 기본 주소 정보 불러오기
-  memberDTO / MemberEntity에 address 추가

## 💻 백엔드 PR 유형

### ✨ 기능 및 API  
- [ ] 새 API 추가
- [ ] 기존 API 수정
- [ ] API의 엔드포인트(URL) 수정
- [x] 데이터베이스 구조 변경 (엔티티, 테이블, 컬럼 수정)
- [ ] API 응답 구조 변경 (ResponseMessage 필드명, 데이터 구조 수정)

### 🛠️ 보안 및 성능      
- [ ] 성능 개선 (쿼리 최적화, 캐싱)  
- [ ] 보안 관련 수정 (인증/인가, 데이터 검증)
- [ ] 예외 처리 개선 (예외 핸들링 로직 추가/수정)

### 😈 버그  
- [ ] 버그 수정

### 🎸 기타  
- [ ] API 문서화 (Swagger 설정 추가/수정)
- [ ] 코드 리팩토링 (파일/폴더명 변경, 코드 스타일 정리)
- [ ] 불필요한 코드 및 파일 삭제
- [ ] 주석 추가 및 수정  
- [ ] 테스트 코드 추가 및 수정
- [ ] 기타

## 📸스크린샷 (선택)



## ✅ PR Checklist
📢 merge 할 분 이름에 체크해주세요.
- [ ] 김규남
- [ ] 김경훈
- [ ] 박재민
- [ ] 정예진
- [x] 정은미

