### PR TITLE
✨[PR]2025/02/24 이미지 변경 로직 / 토큰 시간 수정 - 김규남✨

### DIFF
--- a/funniture/src/main/java/com/ohgiraffers/funniture/auth/filter/JwtAuthorizationFilter.java
+++ b/funniture/src/main/java/com/ohgiraffers/funniture/auth/filter/JwtAuthorizationFilter.java
@@ -40,6 +40,7 @@ public class JwtAuthorizationFilter extends BasicAuthenticationFilter {
         * */
 
         List<String> roleLeessList = Arrays.asList(
+                "/api/v1/member/modify/imageLink",
                 "/api/v1/deliveryaddress/.*",
                 "/api/v1/email",
                 "/api/v1/email/.*",

--- a/funniture/src/main/java/com/ohgiraffers/funniture/member/model/service/MemberService.java
+++ b/funniture/src/main/java/com/ohgiraffers/funniture/member/model/service/MemberService.java
@@ -3,6 +3,7 @@ package com.ohgiraffers.funniture.member.model.service;
 import com.ohgiraffers.funniture.member.entity.MemberEntity;
 import com.ohgiraffers.funniture.member.model.dao.MemberRepository;
 import com.ohgiraffers.funniture.member.model.dto.MemberDTO;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.modelmapper.ModelMapper;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -130,4 +131,23 @@ public class MemberService {
         return result;
 
     }
+
+    @Transactional
+    public void updateMemberImage(MemberDTO memberDTO) {
+        System.out.println("서비스의 memberDTO = " + memberDTO);
+
+        // 데이터베이스에서 기존 회원 정보 조회
+        MemberEntity existingMember = memberRepository.findById(memberDTO.getMemberId())
+                .orElseThrow(() -> new IllegalArgumentException("해당 회원을 찾을 수 없습니다: " + memberDTO.getMemberId()));
+
+        // 새로운 이미지 링크만 업데이트
+        if (memberDTO.getImageLink() != null) {
+            existingMember.setImageLink(memberDTO.getImageLink());
+        }
+
+        // 변경 사항 저장 (변경 감지 또는 save 호출)
+        memberRepository.save(existingMember);
+    }
+
+
 }

--- a/funniture/src/main/resources/application.yml
+++ b/funniture/src/main/resources/application.yml
@@ -49,7 +49,7 @@ mybatis:
 
 jwt:
   key: wERjtIdxQ8lNjF0w/AAiN6HqTASaCAUzSq6nbKefMwf5CbPE8GvwLsClz94uVt9Q1esxYwwXVU+BYn7/mR01Qg==
-  time: 1800000
+  time: 43200000
 
 cloudinary:
   cloud-name: dor26tdln


### PR DESCRIPTION
## #️⃣ Issue Number

#163 
#166 
#167 

## 📝 요약(Summary)

- 사용자 마이 페이지 이미지 불러오기
- 사용자 마이 페이지 이미지 저장 (클라우드너리)
- 토큰 유효 시간 12시간으로 변경

## 💻 백엔드 PR 유형

### ✨ 기능 및 API  
- [x] 새 API 추가
- [ ] 기존 API 수정
- [ ] API의 엔드포인트(URL) 수정
- [ ] 데이터베이스 구조 변경 (엔티티, 테이블, 컬럼 수정)
- [ ] API 응답 구조 변경 (ResponseMessage 필드명, 데이터 구조 수정)

### 🛠️ 보안 및 성능      
- [ ] 성능 개선 (쿼리 최적화, 캐싱)  
- [ ] 보안 관련 수정 (인증/인가, 데이터 검증)
- [ ] 예외 처리 개선 (예외 핸들링 로직 추가/수정)

### 😈 버그  
- [ ] 버그 수정

### 🎸 기타  
- [ ] API 문서화 (Swagger 설정 추가/수정)
- [ ] 코드 리팩토링 (파일/폴더명 변경, 코드 스타일 정리)
- [ ] 불필요한 코드 및 파일 삭제
- [ ] 주석 추가 및 수정  
- [ ] 테스트 코드 추가 및 수정
- [ ] 기타

## 📸스크린샷 (선택)



## ✅ PR Checklist
📢 merge 할 분 이름에 체크해주세요.
- [ ] 김규남
- [ ] 김경훈
- [ ] 박재민
- [ ] 정예진
- [x] 정은미

