### PR TITLE
✨[PR]2025/02/24 사용자 마이페이지 탈퇴자 권한 변경 - 규남 ✨

### DIFF
--- a/funniture/src/main/java/com/ohgiraffers/funniture/member/controller/MemberController.java
+++ b/funniture/src/main/java/com/ohgiraffers/funniture/member/controller/MemberController.java
@@ -231,12 +231,43 @@ public class MemberController {
 
         if (response != null) {
 
-            return ResponseEntity.ok(new ResponseMessage(201, "프로필 사진 변경 성공", null));
+            return ResponseEntity.ok()
+                    .headers(authController.headersMethod())
+                    .body(new ResponseMessage(201, "프로필 사진 변경 성공", null));
 
             // DB 업데이트 로직 수행
         } else {
             System.out.println("파일이 없습니다.");
-            return ResponseEntity.ok(new ResponseMessage(400, "프로필 사진 변경 실패", null));
+            return ResponseEntity.ok()
+                    .headers(authController.headersMethod())
+                    .body(new ResponseMessage(400, "프로필 사진 변경 실패", null));
         }
+    }
+
+    // 회원 탈퇴
+    @Operation(summary = "회원 탈퇴",
+            description = "사용자 페이지에서 회원 탈퇴(권한 변경 LIMIT)"
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "회원 탈퇴 성공"),
+            @ApiResponse(responseCode = "400",description = "회원 탈퇴 실패.")
+    })
+    @PutMapping("/withdraw/{memberId}")
+    public ResponseEntity<ResponseMessage> withdrawByMemberId(@PathVariable String memberId){
+        System.out.println("최초 프론트에서 회원 탈퇴 요청 들왔나 memberId = " + memberId);
+
+        MemberDTO result = memberService.withdrawService(memberId);
+
+        System.out.println("result.getMemberRole() = " + result.getMemberRole());
+        if (result.getMemberRole() == "LIMIT"){
+            return ResponseEntity.ok()
+                    .headers(authController.headersMethod())
+                    .body(new ResponseMessage(201, "회원 탈퇴 성공", null));
+        } else{
+            return ResponseEntity.ok()
+                    .headers(authController.headersMethod())
+                    .body(new ResponseMessage(400, "회원 탈퇴 실패", null));
+        }
+
     }
 }

--- a/funniture/src/main/java/com/ohgiraffers/funniture/member/model/service/MemberService.java
+++ b/funniture/src/main/java/com/ohgiraffers/funniture/member/model/service/MemberService.java
@@ -80,10 +80,8 @@ public class MemberService {
 
     // 마이페이지 비번 변경 전 해당 id에 해당하는 엔티티 찾아오는 로직
     public MemberEntity findByMemberId(String memberId) {
-        System.out.println("비밀번호 변경 전, 서비스로 memberId 넘어 왔나 = " + memberId);
 
         MemberEntity memberEntity = memberRepository.findByMemberId(memberId);
-        System.out.println("서비스에서 아이디에 해당하는 memberEntity 잘 찾았나 = " + memberEntity);
         return memberEntity;
 
     }
@@ -149,5 +147,17 @@ public class MemberService {
         memberRepository.save(existingMember);
     }
 
+    @Transactional
+    public MemberDTO withdrawService(String memberId) {
 
+        MemberEntity memberEntity = memberRepository.findById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 ID의 회원이 존재하지 않습니다."));
+
+        memberEntity.setMemberRole("LIMIT");
+
+        MemberDTO result = modelMapper.map(memberEntity , MemberDTO.class);
+
+        return result;
+
+    }
 }


### PR DESCRIPTION
## #️⃣ Issue Number

#163 
#168 

## 📝 요약(Summary)

- 마이페이지에서 회원 탈퇴 클릭 시, 탈퇴자로 권한 변경
- USER → LIMIT

## 💻 백엔드 PR 유형

### ✨ 기능 및 API  
- [x] 새 API 추가
- [ ] 기존 API 수정
- [ ] API의 엔드포인트(URL) 수정
- [ ] 데이터베이스 구조 변경 (엔티티, 테이블, 컬럼 수정)
- [ ] API 응답 구조 변경 (ResponseMessage 필드명, 데이터 구조 수정)

### 🛠️ 보안 및 성능      
- [ ] 성능 개선 (쿼리 최적화, 캐싱)  
- [ ] 보안 관련 수정 (인증/인가, 데이터 검증)
- [ ] 예외 처리 개선 (예외 핸들링 로직 추가/수정)

### 😈 버그  
- [ ] 버그 수정

### 🎸 기타  
- [x] API 문서화 (Swagger 설정 추가/수정)
- [ ] 코드 리팩토링 (파일/폴더명 변경, 코드 스타일 정리)
- [ ] 불필요한 코드 및 파일 삭제
- [ ] 주석 추가 및 수정  
- [ ] 테스트 코드 추가 및 수정
- [ ] 기타

## 📸스크린샷 (선택)



## ✅ PR Checklist
📢 merge 할 분 이름에 체크해주세요.
- [ ] 김규남
- [ ] 김경훈
- [ ] 박재민
- [ ] 정예진
- [x] 정은미

