### PR TITLE
✨[PR]2025/02/25 사용자에서 제공자 전환 등록 로직 - 김규남✨

### DIFF
--- a/funniture/src/main/java/com/ohgiraffers/funniture/member/controller/OwnerController.java
+++ b/funniture/src/main/java/com/ohgiraffers/funniture/member/controller/OwnerController.java
@@ -1,0 +1,52 @@
+package com.ohgiraffers.funniture.member.controller;
+
+import com.ohgiraffers.funniture.cloudinary.CloudinaryService;
+import com.ohgiraffers.funniture.member.model.dto.MemberDTO;
+import com.ohgiraffers.funniture.member.model.dto.OwnerInfoDTO;
+import com.ohgiraffers.funniture.response.ResponseMessage;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Tag(name = "OWNER API")
+@RestController
+@RequestMapping("/api/v1/owner")
+@RequiredArgsConstructor
+public class OwnerController {
+
+    private final AuthController authController;
+    private final CloudinaryService cloudinaryService;
+
+    @Operation(summary = "제공자 전환 신청",
+            description = "제공자 전환 시 사업자 정보 저장"
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "제공자 전환 신청 성공"),
+            @ApiResponse(responseCode = "404", description = "제공자 전환 신청 실패")
+    })
+    @GetMapping("/register")
+    public ResponseEntity<ResponseMessage> memberList (@RequestBody OwnerInfoDTO ownerInfoDTO) {
+        System.out.println("화면에서 넘어온 ownerInfoDTO"+ ownerInfoDTO);
+
+//        OwnerInfoDTO ownerInfoDTO = memberService.getMemberList(memberId);
+//        System.out.println("✅ 서비스에서 넘어온 로그인 회원 목록 = " + memberDTO);
+
+        if (ownerInfoDTO == null) {
+            return ResponseEntity.ok()
+                    .headers(authController.headersMethod())
+                    .body(new ResponseMessage(404, "회원 정보가 존재하지 않습니다.", null));
+        }
+
+        return ResponseEntity.ok()
+                .headers(authController.headersMethod())
+                .body(new ResponseMessage(200, "로그인 한 회원 목록 조회 성공", null));
+    }
+}


### PR DESCRIPTION
## #️⃣ Issue Number



## 📝 요약(Summary)

- 사용자 → 제공자 전환 등록 요청 처리 로직

## 💻 백엔드 PR 유형

### ✨ 기능 및 API  
- [x] 새 API 추가
- [ ] 기존 API 수정
- [ ] API의 엔드포인트(URL) 수정
- [ ] 데이터베이스 구조 변경 (엔티티, 테이블, 컬럼 수정)
- [ ] API 응답 구조 변경 (ResponseMessage 필드명, 데이터 구조 수정)

### 🛠️ 보안 및 성능      
- [ ] 성능 개선 (쿼리 최적화, 캐싱)  
- [ ] 보안 관련 수정 (인증/인가, 데이터 검증)
- [ ] 예외 처리 개선 (예외 핸들링 로직 추가/수정)

### 😈 버그  
- [ ] 버그 수정

### 🎸 기타  
- [ ] API 문서화 (Swagger 설정 추가/수정)
- [ ] 코드 리팩토링 (파일/폴더명 변경, 코드 스타일 정리)
- [ ] 불필요한 코드 및 파일 삭제
- [ ] 주석 추가 및 수정  
- [ ] 테스트 코드 추가 및 수정
- [ ] 기타

## 📸스크린샷 (선택)



## ✅ PR Checklist
📢 merge 할 분 이름에 체크해주세요.
- [ ] 김규남
- [ ] 김경훈
- [ ] 박재민
- [ ] 정예진
- [x] 정은미

