### PR TITLE
🌐✨[PR]2025/02/28 관리자 페이지 권한 변경 로직 -  김규남 ✨🌐

### DIFF
--- a/funniture/src/main/java/com/ohgiraffers/funniture/member/controller/AdminController.java
+++ b/funniture/src/main/java/com/ohgiraffers/funniture/member/controller/AdminController.java
@@ -112,6 +112,62 @@ public class AdminController {
                 .body(new ResponseMessage(200, "모든 제공자 전환신청 정보 조회 성공", result));
     }
 
+    @Operation(summary = "전체 탈퇴자 정보 조회",
+            description = "관리자 페이지에서 모든 탈퇴자 정보 조회"
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "모든 탈퇴자 정보 조회 성공"),
+            @ApiResponse(responseCode = "404", description = "모든 탈퇴자 정보 조회 실패")
+    })
+    @GetMapping("/leaverList")
+    public ResponseEntity<ResponseMessage> leaverListByAdmin () {
+        System.out.println("✅ 관리자 페이지에서 탈퇴자 데이터 불러오는 컨트롤러 동작");
+
+        List<MemberAndPointDTO> memberAndPointDTO = adminService.getLeaverListByAdmin();
+        System.out.println("✅ 관리자 페이지에서 탈퇴자 데이터 서비스 갔다가 컨트롤러 = " + memberAndPointDTO);
+
+        Map<String , Object> result = new HashMap<>();
+        result.put("result" , memberAndPointDTO);
+
+        if (memberAndPointDTO.isEmpty()) {
+            return ResponseEntity.ok()
+                    .headers(authController.headersMethod())
+                    .body(new ResponseMessage(404, "모든 탈퇴자 정보가 존재하지 않음.", null));
+        }
+
+        return ResponseEntity.ok()
+                .headers(authController.headersMethod())
+                .body(new ResponseMessage(200, "모든 탈퇴자 정보 조회 성공", result));
+    }
+
+    @Operation(summary = "권한 정보 변경",
+            description = "관리자 페이지에서 탈퇴자를 유저로 권한 변경"
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "탈퇴자 회원, 유저로 권한 변경 성공"),
+            @ApiResponse(responseCode = "404", description = "탈퇴자 회원, 유저로 권한 변경 실패")
+    })
+    @PostMapping("/reactivate")
+    public ResponseEntity<ResponseMessage> leaverToUserApproveByAdmin (@RequestBody List<String> userIds) {
+        System.out.println("✅ 관리자 페이지에서 탈퇴자 → 유저 권한 변경 컨트롤러 userIds 잘 받아왔나 : " + userIds);
+
+        Boolean isSuccess = adminService.leaverToUserApproveService(userIds);
+
+        if (isSuccess) {
+            // 성공 응답
+            return ResponseEntity.ok()
+                    .headers(authController.headersMethod())
+                    .body(new ResponseMessage(201, "탈퇴자 회원, 유저로 권한이 성공적으로 변경되었습니다.", null));
+        } else {
+            // 실패 응답
+            return ResponseEntity.status(400) // 상태 코드 400 (Bad Request)
+                    .headers(authController.headersMethod())
+                    .body(new ResponseMessage(400, "탈퇴자 회원 중 일부 또는 전체가 이미 유저 권한입니다.", null));
+        }
+    }
+
+
+
 //    @Operation(summary = "모달에 표시될 제공자 전환 데이터",
 //            description = "관리자 페이지에서 모달에 표시될 제공자로 전환 요청 정보 조회"
 //    )

--- a/funniture/src/main/java/com/ohgiraffers/funniture/member/entity/MemberAndPointEntity.java
+++ b/funniture/src/main/java/com/ohgiraffers/funniture/member/entity/MemberAndPointEntity.java
@@ -1,10 +1,7 @@
 package com.ohgiraffers.funniture.member.entity;
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.*;
 
 import java.time.LocalDateTime;
 
@@ -14,6 +11,7 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @Getter
 @ToString
+@Builder(toBuilder = true) // toBuilder 추가
 public class MemberAndPointEntity {
 
     @Id

--- a/funniture/src/main/java/com/ohgiraffers/funniture/member/model/dao/AdminRepository.java
+++ b/funniture/src/main/java/com/ohgiraffers/funniture/member/model/dao/AdminRepository.java
@@ -67,6 +67,18 @@ public interface AdminRepository extends JpaRepository<MemberAndPointEntity, Str
     List<Object[]> AllConvertListByAdmin();
 
 
+    @Query(value = "SELECT a.member_id, a.user_name, a.phone_number, a.email, a.signup_date, a.member_role, \n" +
+            "IFNULL(b.current_point, 0) AS current_point \n" +
+            "FROM tbl_member a \n" +
+            "LEFT JOIN tbl_point b ON a.member_id = b.member_id \n" +
+            "WHERE a.member_role = 'LIMIT' \n" +
+            "ORDER BY a.member_id ASC\n",
+            nativeQuery = true)
+    List<Object[]> AllLeaverListByAdmin();
+
+
+
+
 //    @Query("SELECT new com.ohgiraffers.funniture.member.model.dto.AppOwnerListModalDTO(" +
 //            "m.memberId, m.userName, m.phoneNumber, m.email, m.signupDate, m.memberRole, " +
 //            "new com.ohgiraffers.funniture.member.model.dto.OwnerInfoDTO(" +

--- a/funniture/src/main/java/com/ohgiraffers/funniture/member/model/service/AdminService.java
+++ b/funniture/src/main/java/com/ohgiraffers/funniture/member/model/service/AdminService.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.modelmapper.ModelMapper;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -50,6 +51,46 @@ public class AdminService {
                 .map(AppOwnerListDTO::new) // ✅ 새로운 생성자 활용
                 .collect(Collectors.toList());
     }
+
+    // 관리자 페이지에서 모든 탈퇴자 정보 불러오는 로직
+    public List<MemberAndPointDTO> getLeaverListByAdmin() {
+        List<Object[]> memberEntityList = adminRepository.AllLeaverListByAdmin();
+        System.out.println("레파지토리에서 잘 조회해 왔는지 memberEntityList = " + memberEntityList);
+
+        return memberEntityList.stream()
+                .map(MemberAndPointDTO::new) // ✅ 새로운 생성자 활용
+                .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public boolean leaverToUserApproveService(List<String> userIds) {
+        boolean isSuccess = true;
+
+        for (String userId : userIds) {
+            System.out.println("✅ 권한 변경 처리 중: 사용자 ID = " + userId);
+
+            // 1. 기존 회원 정보 조회
+            MemberAndPointEntity member = adminRepository.findById(userId)
+                    .orElseThrow(() -> new RuntimeException("회원 정보를 찾을 수 없습니다: " + userId));
+
+            // 2. member_role이 'LIMIT'인 경우만 'USER'로 변경
+            if ("LIMIT".equals(member.getMemberRole())) {
+                MemberAndPointEntity updatedMember = member.toBuilder()
+                        .memberRole("USER") // member_role 값 변경
+                        .build();
+
+                // 3. 변경된 객체 저장 (업데이트)
+                adminRepository.save(updatedMember);
+
+                System.out.println("✅ 권한이 'USER'로 변경되었습니다: 사용자 ID = " + userId);
+            } else {
+                System.out.println("❌ 권한 변경 불필요: 사용자 ID = " + userId);
+                isSuccess = false; // 권한 변경이 불필요한 경우 실패로 간주
+            }
+        }
+        return isSuccess;
+    }
+
 
 //    public List<AppOwnerListModalDTO> getConvertAppListByAdminModal() {
 //            return adminRepository.findConvertAppListByAdminModal();

--- a/funniture/src/main/java/com/ohgiraffers/funniture/member/model/service/MemberService.java
+++ b/funniture/src/main/java/com/ohgiraffers/funniture/member/model/service/MemberService.java
@@ -13,6 +13,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -157,6 +158,9 @@ public class MemberService {
         MemberEntity memberEntity = memberRepository.findById(memberId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 ID의 회원이 존재하지 않습니다."));
 
+        // 현재 시간을 가져와서 signupDate에 설정
+        LocalDateTime currentTime = LocalDateTime.now();
+        memberEntity.setSignupDate(currentTime); // 현재 시간을 signupDate에 설정
         memberEntity.setMemberRole("LIMIT");
 
         MemberDTO result = modelMapper.map(memberEntity , MemberDTO.class);


### PR DESCRIPTION
## #️⃣ Issue Number

#221 
#222 
#223 

## 📝 요약(Summary)

- 관리자 페이지에서 탈퇴자 권한 불러오기
- 관리자 페이지에서 탈퇴자 → 사용자 권한 변경 로직

## 💻 백엔드 PR 유형

### ✨ 기능 및 API  
- [x] 새 API 추가
- [ ] 기존 API 수정
- [ ] API의 엔드포인트(URL) 수정
- [ ] 데이터베이스 구조 변경 (엔티티, 테이블, 컬럼 수정)
- [ ] API 응답 구조 변경 (ResponseMessage 필드명, 데이터 구조 수정)

### 🛠️ 보안 및 성능      
- [ ] 성능 개선 (쿼리 최적화, 캐싱)  
- [ ] 보안 관련 수정 (인증/인가, 데이터 검증)
- [ ] 예외 처리 개선 (예외 핸들링 로직 추가/수정)

### 😈 버그  
- [ ] 버그 수정

### 🎸 기타  
- [x] API 문서화 (Swagger 설정 추가/수정)
- [ ] 코드 리팩토링 (파일/폴더명 변경, 코드 스타일 정리)
- [ ] 불필요한 코드 및 파일 삭제
- [ ] 주석 추가 및 수정  
- [ ] 테스트 코드 추가 및 수정
- [ ] 기타

## 📸스크린샷 (선택)



## ✅ PR Checklist
📢 merge 할 분 이름에 체크해주세요.
- [ ] 김규남
- [ ] 김경훈
- [ ] 박재민
- [ ] 정예진
- [x] 정은미

