### PR TITLE
🌐✨[PR]2025/02/28 관리자 페이지 사용자 → 탈퇴자 권한 변경  - 김규남✨🌐

### DIFF
--- a/funniture/src/main/java/com/ohgiraffers/funniture/member/controller/AdminController.java
+++ b/funniture/src/main/java/com/ohgiraffers/funniture/member/controller/AdminController.java
@@ -140,7 +140,7 @@ public class AdminController {
                 .body(new ResponseMessage(200, "모든 탈퇴자 정보 조회 성공", result));
     }
 
-    @Operation(summary = "권한 정보 변경",
+    @Operation(summary = "탈퇴자 권한 정보 변경",
             description = "관리자 페이지에서 탈퇴자를 유저로 권한 변경"
     )
     @ApiResponses({
@@ -160,12 +160,37 @@ public class AdminController {
                     .body(new ResponseMessage(201, "탈퇴자 회원, 유저로 권한이 성공적으로 변경되었습니다.", null));
         } else {
             // 실패 응답
-            return ResponseEntity.status(400) // 상태 코드 400 (Bad Request)
+            return ResponseEntity.ok() // 상태 코드 400 (Bad Request)
                     .headers(authController.headersMethod())
                     .body(new ResponseMessage(400, "탈퇴자 회원 중 일부 또는 전체가 이미 유저 권한입니다.", null));
         }
     }
 
+    @Operation(summary = "사용자 권한 정보 변경",
+            description = "관리자 페이지에서 사용자를 탈퇴자로 권한 변경"
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "사용자자 회원, 탈퇴자로 권한 변경 성공"),
+            @ApiResponse(responseCode = "404", description = "사용자자 회원, 탈퇴자로 권한 변경 실패")
+    })
+    @PostMapping("/deactivate")
+    public ResponseEntity<ResponseMessage> userToLeaverApproveByAdmin (@RequestBody List<String> userIds) {
+        System.out.println("✅ 관리자 페이지에서 유저 → 탈퇴자 권한 변경 컨트롤러 userIds 잘 받아왔나 : " + userIds);
+
+        Boolean isSuccess = adminService.userToLeaverApproveService(userIds);
+
+        if (isSuccess) {
+            // 성공 응답
+            return ResponseEntity.ok()
+                    .headers(authController.headersMethod())
+                    .body(new ResponseMessage(201, "사용자 회원, 탈퇴자로 권한이 성공적으로 변경되었습니다.", null));
+        } else {
+            // 실패 응답
+            return ResponseEntity.ok() // 상태 코드 400 (Bad Request)
+                    .headers(authController.headersMethod())
+                    .body(new ResponseMessage(400, "사용자 회원 중 일부 또는 전체가 이미 탈퇴자 권한입니다.", null));
+        }
+    }
 
 
 //    @Operation(summary = "모달에 표시될 제공자 전환 데이터",

--- a/funniture/src/main/java/com/ohgiraffers/funniture/member/model/service/AdminService.java
+++ b/funniture/src/main/java/com/ohgiraffers/funniture/member/model/service/AdminService.java
@@ -62,6 +62,7 @@ public class AdminService {
                 .collect(Collectors.toList());
     }
 
+    // 관리자 페이지에서 탈퇴자를 사용자 권한으로 변경하는 로직
     @Transactional
     public boolean leaverToUserApproveService(List<String> userIds) {
         boolean isSuccess = true;
@@ -91,6 +92,35 @@ public class AdminService {
         return isSuccess;
     }
 
+    // 관리자 페이지에서 사용자를 탈퇴자 권한으로 변경하는 로직
+    @Transactional
+    public boolean userToLeaverApproveService(List<String> userIds) {
+        boolean isSuccess = true;
+
+        for (String userId : userIds) {
+            System.out.println("✅ 권한 변경 처리 중: 사용자 ID = " + userId);
+
+            // 1. 기존 회원 정보 조회
+            MemberAndPointEntity member = adminRepository.findById(userId)
+                    .orElseThrow(() -> new RuntimeException("회원 정보를 찾을 수 없습니다: " + userId));
+
+            // 2. member_role이 'USER'인 경우만 'LIMIT'로 변경
+            if ("USER".equals(member.getMemberRole())) {
+                MemberAndPointEntity updatedMember = member.toBuilder()
+                        .memberRole("LIMIT") // member_role 값 변경
+                        .build();
+
+                // 3. 변경된 객체 저장 (업데이트)
+                adminRepository.save(updatedMember);
+
+                System.out.println("✅ 권한이 'LIMIT'로 변경되었습니다: 사용자 ID = " + userId);
+            } else {
+                System.out.println("❌ 권한 변경 불필요: 사용자 ID = " + userId);
+                isSuccess = false; // 권한 변경이 불필요한 경우 실패로 간주
+            }
+        }
+        return isSuccess;
+    }
 
 //    public List<AppOwnerListModalDTO> getConvertAppListByAdminModal() {
 //            return adminRepository.findConvertAppListByAdminModal();


### PR DESCRIPTION
## #️⃣ Issue Number

#221 
#223 

## 📝 요약(Summary)

- 관리자 페이지에서 사용자 → 탈퇴자 권한 변경 로직

## 💻 백엔드 PR 유형

### ✨ 기능 및 API  
- [x] 새 API 추가
- [ ] 기존 API 수정
- [ ] API의 엔드포인트(URL) 수정
- [ ] 데이터베이스 구조 변경 (엔티티, 테이블, 컬럼 수정)
- [ ] API 응답 구조 변경 (ResponseMessage 필드명, 데이터 구조 수정)

### 🛠️ 보안 및 성능      
- [ ] 성능 개선 (쿼리 최적화, 캐싱)  
- [ ] 보안 관련 수정 (인증/인가, 데이터 검증)
- [ ] 예외 처리 개선 (예외 핸들링 로직 추가/수정)

### 😈 버그  
- [ ] 버그 수정

### 🎸 기타  
- [ ] API 문서화 (Swagger 설정 추가/수정)
- [ ] 코드 리팩토링 (파일/폴더명 변경, 코드 스타일 정리)
- [ ] 불필요한 코드 및 파일 삭제
- [ ] 주석 추가 및 수정  
- [ ] 테스트 코드 추가 및 수정
- [ ] 기타

## 📸스크린샷 (선택)



## ✅ PR Checklist
📢 merge 할 분 이름에 체크해주세요.
- [ ] 김규남
- [ ] 김경훈
- [ ] 박재민
- [ ] 정예진
- [x] 정은미

