### PR TITLE
:art:[PR]2025/03/03 제공자 예약확정 API 수정 - 정은미:art:

### DIFF
--- a/funniture/src/main/java/com/ohgiraffers/funniture/auth/filter/JwtAuthorizationFilter.java
+++ b/funniture/src/main/java/com/ohgiraffers/funniture/auth/filter/JwtAuthorizationFilter.java
@@ -73,7 +73,7 @@ public class JwtAuthorizationFilter extends BasicAuthenticationFilter {
                 "/api/v1/rental/\\d+",
                 "/api/v1/rental/\\w+",
                 "/api/v1/rental/\\d+/confirm",
-                "/api/v1/rental/\\w+/confirm",
+                "/api/v1/rental/confirmBatch",
                 "/api/v1/chat/.*",
                 "/api/v1/deliveryaddress",
                 "/api/v1/deliveryaddress/\\w+",

--- a/funniture/src/main/java/com/ohgiraffers/funniture/rental/controllers/RentalController.java
+++ b/funniture/src/main/java/com/ohgiraffers/funniture/rental/controllers/RentalController.java
@@ -179,17 +179,35 @@ public class RentalController {
             @ApiResponse(responseCode = "200", description = "예약완료로 상태 변경 되었습니다.")
     })
     
-    // 예약확정
-    @PutMapping("/{rentalNo}/confirm")
-    public ResponseEntity<ResponseMessage> confirmRental(@PathVariable String rentalNo) {
-        String rentalState = "예약완료";  // 상태값 고정
+//    // 예약확정
+//    @PutMapping("/{rentalNo}/confirm")
+//    public ResponseEntity<ResponseMessage> confirmRental(@PathVariable String rentalNo) {
+//        String rentalState = "예약완료";  // 상태값 고정
+//
+//        HttpHeaders headers = new HttpHeaders();
+//        headers.setContentType(new MediaType("Application", "json", Charset.forName("UTF-8")));
+//
+//        rentalService.confirmRental(rentalNo, rentalState);
+//
+//        return ResponseEntity.ok().headers(headers).body(new ResponseMessage(200, "예약완료로 상태 변경 되었습니다.", null));
+//    }
 
+    @PutMapping("/confirmBatch")
+    public ResponseEntity<ResponseMessage> confirmRentals(@RequestParam List<String> rentalNos) {
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(new MediaType("Application", "json", Charset.forName("UTF-8")));
 
-        rentalService.confirmRental(rentalNo, rentalState);
+        System.out.println("rentalNos = " + rentalNos);
 
-        return ResponseEntity.ok().headers(headers).body(new ResponseMessage(200, "예약완료로 상태 변경 되었습니다.", null));
+        try {
+            rentalService.confirmRentals(rentalNos);  // 여러 개의 예약번호 처리
+            return ResponseEntity.ok().headers(headers).body(new ResponseMessage(200, "선택된 예약들이 예약완료로 상태 변경되었습니다.", null));
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .headers(headers)
+                    .body(new ResponseMessage(500, "예약 상태 변경 중 오류가 발생했습니다.", null));
+        }
+
     }
 
 

--- a/funniture/src/main/java/com/ohgiraffers/funniture/rental/model/dao/RentalRepository.java
+++ b/funniture/src/main/java/com/ohgiraffers/funniture/rental/model/dao/RentalRepository.java
@@ -2,6 +2,7 @@ package com.ohgiraffers.funniture.rental.model.dao;
 
 import com.ohgiraffers.funniture.rental.entity.RentalEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -15,7 +16,6 @@ public interface RentalRepository extends JpaRepository<RentalEntity, String> {
 
     @Query("SELECT COUNT(r) FROM rental r WHERE DATE(r.orderDate) = :orderDateOnly")
     int countByOrderDate(@Param("orderDateOnly") LocalDate orderDateOnly);
-
 
     Optional<RentalEntity> findByRentalNo(String rentalNo);
 }

--- a/funniture/src/main/java/com/ohgiraffers/funniture/rental/model/service/RentalService.java
+++ b/funniture/src/main/java/com/ohgiraffers/funniture/rental/model/service/RentalService.java
@@ -138,12 +138,25 @@ public class RentalService {
         return ownerRentalRepositoryCustom.findRentalListByOwner(ownerNo, period, rentalTab, pageable);
     }
 
+//    @Transactional
+//    public void confirmRental(String rentalNo, String rentalState) {
+//
+//        RentalEntity rental = rentalRepository.findByRentalNo(rentalNo)
+//                .orElseThrow(() -> new IllegalArgumentException("해당 예약 정보를 찾을 수 없습니다: " + rentalNo));
+//
+//        rental.changeRentalState(rentalState);  // Setter 대신 메서드 사용
+//    }
+
+
     @Transactional
-    public void confirmRental(String rentalNo, String rentalState) {
+    public void confirmRentals(List<String> rentalNos) {
+        System.out.println("rentalNos 서비스 = " + rentalNos);
+        for (String rentalNo : rentalNos) {
+            System.out.println("rentalNo = " + rentalNo);
+            RentalEntity rental = rentalRepository.findByRentalNo(rentalNo)
+                    .orElseThrow(() -> new IllegalArgumentException("해당 예약 정보를 찾을 수 없습니다: " + rentalNo));
 
-        RentalEntity rental = rentalRepository.findByRentalNo(rentalNo)
-                .orElseThrow(() -> new IllegalArgumentException("해당 예약 정보를 찾을 수 없습니다: " + rentalNo));
-
-        rental.changeRentalState(rentalState);  // Setter 대신 메서드 사용
+            rental.changeRentalState("예약완료");  // 상태 변경
+        }
     }
 }


### PR DESCRIPTION
## #️⃣ Issue Number

#246

## 📝 요약(Summary)

- 제공자 예약확정 다중선택 가능하게  API 수정

## 💻 백엔드 PR 유형

### ✨ 기능 및 API  
- [ ] 새 API 추가
- [x] 기존 API 수정
- [ ] API의 엔드포인트(URL) 수정
- [ ] 데이터베이스 구조 변경 (엔티티, 테이블, 컬럼 수정)
- [ ] API 응답 구조 변경 (ResponseMessage 필드명, 데이터 구조 수정)

### 🛠️ 보안 및 성능      
- [ ] 성능 개선 (쿼리 최적화, 캐싱)  
- [ ] 보안 관련 수정 (인증/인가, 데이터 검증)
- [ ] 예외 처리 개선 (예외 핸들링 로직 추가/수정)

### 😈 버그  
- [ ] 버그 수정

### 🎸 기타  
- [ ] API 문서화 (Swagger 설정 추가/수정)
- [ ] 코드 리팩토링 (파일/폴더명 변경, 코드 스타일 정리)
- [ ] 불필요한 코드 및 파일 삭제
- [ ] 주석 추가 및 수정  
- [ ] 테스트 코드 추가 및 수정
- [ ] 기타

## 📸스크린샷 (선택)

![image](https://github.com/user-attachments/assets/a189a6b8-d1ed-4811-903b-0b6bce70dadb)

## ✅ PR Checklist
📢 merge 할 분 이름에 체크해주세요.
- [ ] 김규남
- [ ] 김경훈
- [ ] 박재민
- [ ] 정예진
- [x] 정은미

