### PR TITLE
:sparkles:[PR]2025/03/06 주문번호별 예약대기,예약완료 상태인 예약 배송지 수정 - 정은미:sparkles:

### DIFF
--- a/funniture/src/main/java/com/ohgiraffers/funniture/rental/controllers/RentalController.java
+++ b/funniture/src/main/java/com/ohgiraffers/funniture/rental/controllers/RentalController.java
@@ -128,13 +128,10 @@ public class RentalController {
         return ResponseEntity.ok().headers(headers).body(new ResponseMessage(200, "사용자의 예약진행상태별 count 성공", res));
     }
 
-
-    @Operation(summary = "사용자의 예약 전체 조회",
-            description = "사용자 마이페이지 주문/배송에서 사용",
+    @Operation(summary = "사용자 사용중인 상품 조회",
+            description = "사용자 마이페이지 사용상품/반납에서 사용",
             parameters = {
                     @Parameter(name = "memberId", description = "사용자 ID(필수)"),
-                    @Parameter(name = "period", description = "조회 할 개월수(개월수에 orderDate 가 해당되면 조회) ex.1개월전~현재=1MONTH,3개월전~현재=3MONTH (선택)"),
-                    @Parameter(name = "searchDate", description = "조회 할 날짜(선택)"),
                     @Parameter(name = "offset", description = "현재페이지")
             }
     )
@@ -195,6 +192,30 @@ public class RentalController {
         res.put("rentalDetail", rentalDetail);
 
         return ResponseEntity.ok().headers(headers).body(new ResponseMessage(200, "예약 상세 조회 성공", res));
+    }
+
+    @Operation(summary = "주문번호별 예약대기,예약완료 상태인 예약 배송지 수정",
+            description = "사용자 주문상세페이지에서 사용",
+            parameters = {
+                    @Parameter(name = "rentalNo", description = "주문번호"),
+                    @Parameter(name = "destinationNo", description = "새로운 배송지 식별번호")
+            }
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "배송지 수정이 완료되었습니다.")
+    })
+    // 사용자 예약 배송지 변경
+    @PutMapping("/{rentalNo}/deliveryaddress")
+    public ResponseEntity<ResponseMessage> updateRentalDeliveryAddress(@PathVariable String rentalNo,
+                                                                       @RequestBody String destinationNo) {
+        int newDestinationNo = Integer.parseInt(destinationNo);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(new MediaType("Application", "json", Charset.forName("UTF-8")));
+
+        rentalService.updateRentalDeliveryAddress(rentalNo, newDestinationNo);
+
+        return ResponseEntity.ok().headers(headers).body(new ResponseMessage(200, "배송지 수정이 완료되었습니다.", null));
     }
 
     /* comment.-------------------------------------------- 제공자 -----------------------------------------------*/

--- a/funniture/src/main/java/com/ohgiraffers/funniture/rental/entity/RentalEntity.java
+++ b/funniture/src/main/java/com/ohgiraffers/funniture/rental/entity/RentalEntity.java
@@ -68,4 +68,8 @@ public class RentalEntity {
         this.deliverCom = newDeliverCom;
     }
 
+    public void changeDestinationNo(int newDestinationNo) {
+        this.destinationNo = newDestinationNo;
+    }
+
 }

--- a/funniture/src/main/java/com/ohgiraffers/funniture/rental/model/dao/UserRentalRepositoryCustomImpl.java
+++ b/funniture/src/main/java/com/ohgiraffers/funniture/rental/model/dao/UserRentalRepositoryCustomImpl.java
@@ -49,7 +49,7 @@ public class UserRentalRepositoryCustomImpl implements UserRentalRepositoryCusto
             if (period == null) {
                 endDate = searchDate.atTime(23, 59, 59); // 선택한 날짜 하루만 조회
             } else {
-                endDate = LocalDateTime.now(); // 1개월/3개월 버튼 클릭 시, 현재 날짜까지 조회
+                endDate = LocalDateTime.now();
             }
 
             whereCondition.and(rental.orderDate.between(startDate, endDate));
@@ -77,7 +77,7 @@ public class UserRentalRepositoryCustomImpl implements UserRentalRepositoryCusto
                 .from(rental)
                 .join(rental.productEntity, product)
                 .join(rental.rentalOptionInfoEntity, optionInfo)
-                .where(rental.memberId.eq(memberId));
+                .where(whereCondition);
 
         Long countResult = countQuery.fetchOne();
         long totalCount = (countResult != null) ? countResult : 0;

--- a/funniture/src/main/java/com/ohgiraffers/funniture/rental/model/service/RentalService.java
+++ b/funniture/src/main/java/com/ohgiraffers/funniture/rental/model/service/RentalService.java
@@ -136,6 +136,23 @@ public class RentalService {
         return detailRentalRepositoryCustom.findRentalDetail(rentalNo);
     }
 
+    // 사용자 예약 배송지 변경
+    @Transactional
+    public void updateRentalDeliveryAddress(String rentalNo, int newDestinationNo) {
+
+        RentalEntity rentalEntity = rentalRepository.findById(rentalNo)
+                .orElseThrow(() -> new IllegalArgumentException("해당 예약이 존재하지 않습니다."));
+
+        // 예약 상태가 "예약대기" 또는 "예약완료"인 경우만 변경 가능
+        if (!"예약대기".equals(rentalEntity.getRentalState()) &&
+                !"예약완료".equals(rentalEntity.getRentalState())) {
+            throw new IllegalStateException("현재 상태에서는 배송지를 변경할 수 없습니다.");
+        }
+
+        // 배송지(destinationNo) 변경
+        rentalEntity.changeDestinationNo(newDestinationNo);
+    }
+
 /* comment.-------------------------------------------- 관리자 -----------------------------------------------*/
     // 관리자 - 예약 조회(쿼리 DSL)
     public Page<AdminRentalViewDTO> findRentalAllListByAdmin(AdminRentalSearchCriteria criteria, Criteria cri) {


### PR DESCRIPTION
## #️⃣ Issue Number

#290

## 📝 요약(Summary)

- 사용자 주문상세 -> 주문번호별 예약대기,예약완료 상태인 예약 배송지 수정 API

## 💻 백엔드 PR 유형

### ✨ 기능 및 API  
- [ ] 새 API 추가
- [ ] 기존 API 수정
- [ ] API의 엔드포인트(URL) 수정
- [ ] 데이터베이스 구조 변경 (엔티티, 테이블, 컬럼 수정)
- [ ] API 응답 구조 변경 (ResponseMessage 필드명, 데이터 구조 수정)

### 🛠️ 보안 및 성능      
- [ ] 성능 개선 (쿼리 최적화, 캐싱)  
- [ ] 보안 관련 수정 (인증/인가, 데이터 검증)
- [ ] 예외 처리 개선 (예외 핸들링 로직 추가/수정)

### 😈 버그  
- [ ] 버그 수정

### 🎸 기타  
- [ ] API 문서화 (Swagger 설정 추가/수정)
- [ ] 코드 리팩토링 (파일/폴더명 변경, 코드 스타일 정리)
- [ ] 불필요한 코드 및 파일 삭제
- [ ] 주석 추가 및 수정  
- [ ] 테스트 코드 추가 및 수정
- [ ] 기타

## 📸스크린샷 (선택)

![image](https://github.com/user-attachments/assets/606c3b18-5acc-4976-b6c9-bf1982395d63)

## ✅ PR Checklist
📢 merge 할 분 이름에 체크해주세요.
- [ ] 김규남
- [ ] 김경훈
- [ ] 박재민
- [ ] 정예진
- [ ] 정은미

